### PR TITLE
Fixing two bugs with the librato python package

### DIFF
--- a/librato/librato.py
+++ b/librato/librato.py
@@ -19,7 +19,7 @@ class Librato(panoply.DataSource):
         # self._url = build_url(source.get("user"), source.get("token"))
         self._meta_page = 0
         self._current_metric = 0
-        self._auth = base64.encodestring("%(user)s:%(token)s" % source).strip()
+        self._auth = base64.b64encode("%(user)s:%(token)s" % source).strip()
 
         # create the list of metrics along with their start timestamp
         source_metrics = source.get("metrics", [])

--- a/librato/librato.py
+++ b/librato/librato.py
@@ -22,13 +22,15 @@ class Librato(panoply.DataSource):
         self._auth = base64.encodestring("%(user)s:%(token)s" % source).strip()
 
         # create the list of metrics along with their start timestamp
+        source_metrics = source.get("metrics", [])
+        source_metrics = source_metrics if source_metrics else []
         self._metrics = map(lambda metric: {
             "name": metric, 
 
              # the ._read() method may change that timestamp in order to 
              # paginate over the results
             "start": start
-        }, source.get("metrics", []))
+        }, source_metrics)
 
         # progress counters
         self._total = len(self._metrics)
@@ -149,6 +151,3 @@ class LibratoError(Exception):
         # no descriptive error message was extracted, just return the original
         # generic error.
         return err
-
-
-

--- a/librato/librato.py
+++ b/librato/librato.py
@@ -22,7 +22,7 @@ class Librato(panoply.DataSource):
         self._auth = base64.b64encode("%(user)s:%(token)s" % source).strip()
 
         # create the list of metrics along with their start timestamp
-        source_metrics = source.get("metrics", [])
+        source_metrics = source.get("metrics", None)
         source_metrics = source_metrics if source_metrics else []
         self._metrics = map(lambda metric: {
             "name": metric, 


### PR DESCRIPTION
There was a bug with the source metrics which could have been None which in turn would break the `map()` function, add a check to transform falsey values into an empty list

The second bug was due to `base64.encodestring` which enters new lines after 76 characters causing anything other than really short emails to break the `Authorization header` (since the token itself is already 64 characters long), changed it into `base64.b64encode` which does not carry this liability.

Code reviewers (chose the last 2 people who worked on it): @kensaggy @alonbrody 
